### PR TITLE
Fix/issue-148

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,8 @@ services:
     command: bash -c "apk add --update ttf-dejavu && rm -rf /var/cache/apk/* && catalina.sh run"
     volumes:
       - ./apps:/usr/local/tomcat/webapps/
+      - tomcat_test_result_attachments:/usr/local/tomcat/project
+      - tomcat_audit_attachments:/usr/local/tomcat/audits
     links:
       - db:database
     ports:
@@ -56,3 +58,7 @@ services:
       - ./apps:/app/webapps
     depends_on:
       - tomcat
+
+volumes:
+  tomcat_test_result_attachments:
+  tomcat_audit_attachments:


### PR DESCRIPTION
# PR Details
There reason for artifacts error is that the paths to the added files are stored in the database and the files themselves are located in /usr/local/tomcat/ so that they are not preserved when container is created on update.
To keep the files the named volumes for audit and test result attachments have been added.

## Related Issue
https://github.com/aquality-automation/aquality-tracking/issues/148

## How Has This Been Tested
validated manually: attachments and audit results are preserved after aquality tracking update

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
